### PR TITLE
Change application to run on subpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Create a `.env` file in the `client` folder with the following fields:
 | REACT_APP_DOMAIN | Domain used for the host address | | Angela |
 | REACT_APP_SOCKET_PATH | Path for sockets to use coming from the domain, usually ends with `/socket.io` | | Angela |
 | REACT_APP_SERVER_PATH | Path to make API calls to the server | | Angela |
+| PUBLIC_URL | URL for where the application will run | | Pranav |
 
 Add them to the `.env` file like so:
 ```

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+  <base href="%PUBLIC_URL%/">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -42,6 +42,5 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    hello! go to <a href="">the office hours queue</a> or the <a href="/lab">the lab checkin site</a>
   </body>
 </html>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -42,5 +42,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    hello! go to <a href="">the office hours queue</a> or the <a href="/lab">the lab checkin site</a>
   </body>
 </html>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,7 +33,7 @@ function App() {
       <LocalizationProvider dateAdapter={AdapterLuxon}>
         <ThemeContext.Provider value={theme}>
           <GoogleOAuthProvider clientId={process.env.REACT_APP_GOOGLE_CLIENT_ID}>
-            <Router>
+            <Router basename={process.env.PUBLIC_URL}>
               <Routes>
                 <Route path='/' element={<Home theme={theme || darkTheme}/>} />
                 <Route path='/settings' element={<Settings/>} />

--- a/client/src/components/navbar/Navbar.tsx
+++ b/client/src/components/navbar/Navbar.tsx
@@ -76,8 +76,8 @@ export default function Navbar(props) {
     const newPages = [];
 
     if (isAuthenticated && isTA) {
-      newPages.push(createPage('Settings', '/settings'));
-      newPages.push(createPage('Metrics', '/metrics'));
+      newPages.push(createPage('Settings', 'settings'));
+      newPages.push(createPage('Metrics', 'metrics'));
     }
 
     setPages(newPages);
@@ -85,7 +85,7 @@ export default function Navbar(props) {
 
   function handleLogout() {
     removeCookie('user');
-    window.location.href = '/';
+    window.location.href = '';
   }
 
   function openAlert() {

--- a/client/src/components/navbar/OHQueueHeader.tsx
+++ b/client/src/components/navbar/OHQueueHeader.tsx
@@ -5,7 +5,7 @@ import {
 
 export default function OHQueueHeader() {
   return (
-    <Link variant="h6" color="#FFFFFF" fontWeight='bold' href="/" underline="none" sx={{pt: 0.3}}>
+    <Link variant="h6" color="#FFFFFF" fontWeight='bold' href="" underline="none" sx={{pt: 0.3}}>
       15-122 Office Hours Queue
     </Link>
   );

--- a/client/src/http-common.tsx
+++ b/client/src/http-common.tsx
@@ -29,7 +29,7 @@ httpInstance.interceptors.response.use(
     (res) => {
       if (res.data.isOwner && !window.location.href.includes('settings')) {
       // Redirect owner to settings page
-        window.location.href = '/settings';
+        window.location.href = 'settings';
       }
       // COMMENTED OUT SO ONLY TOAST IF ERROR
       // if (res.data.message) {
@@ -40,7 +40,7 @@ httpInstance.interceptors.response.use(
     (err) => {
       if (err.response.status === 404) {
       // Redirect to homepage
-        window.location.href = '/';
+        window.location.href = '';
       }
       if (err.response.data.message) {
         const message = err.message + ': ' + err.response.data.message;


### PR DESCRIPTION
Updated the application so that we can serve it from a subdirectory of the URL, defined by a `PUBLIC_URL` variable in `/client/.env`. 

Done so that we can have the app served from `/ohq` on the production server

To test:
- add `PUBLIC_URL` to `/client/.env` and set its value to whatever (such as `/ohq`)
- just click on everything and check that it works (i..e, routes, buttons, services, etc.)