### PR TITLE
Fixed bugs with metrics page (fixes #205)

### DIFF
--- a/client/src/components/metrics/CumulativeStats.tsx
+++ b/client/src/components/metrics/CumulativeStats.tsx
@@ -16,7 +16,7 @@ export default function CumulativeStats(props) {
     });
 
     MetricsService.getAvgTimePerQuestion().then((res) => {
-      setAvgTimePerQuestion(res.data.avgTimePerQuestion);
+      setAvgTimePerQuestion(res.data.averageTime);
     });
 
     MetricsService.getTotalAvgWaitTime().then((res) => {

--- a/client/src/components/metrics/Graph.tsx
+++ b/client/src/components/metrics/Graph.tsx
@@ -48,7 +48,7 @@ export default function Graph() {
               style={{textAnchor: 'middle'}}
             />
           </XAxis>
-          <YAxis dataKey="students">
+          <YAxis dataKey="students" domain={[0, 'dataMax']}>
             <Label
               value={'Number of Students'}
               position="left"
@@ -76,7 +76,7 @@ export default function Graph() {
               style={{textAnchor: 'middle'}}
             />
           </XAxis>
-          <YAxis dataKey="students">
+          <YAxis dataKey="students" domain={[0, 'dataMax']}>
             <Label
               value={'Number of Students'}
               position="left"
@@ -97,7 +97,12 @@ export default function Graph() {
         <BarChart margin={{top: 40, right: 0, bottom: 40, left: 50}} data={numStudentsPerDay}>
           <CartesianGrid stroke="#ccc" />
           <XAxis dataKey="day" />
-          <YAxis dataKey="students">
+          <Label
+            value={'Day'}
+            position="bottom"
+            style={{textAnchor: 'middle'}}
+          />
+          <YAxis dataKey="students" domain={[0, 'dataMax']}>
             <Label
               value={'Number of Students'}
               position="left"

--- a/client/src/components/metrics/OverallStats.tsx
+++ b/client/src/components/metrics/OverallStats.tsx
@@ -18,7 +18,7 @@ export default function OverallStats() {
     });
 
     MetricsService.getNumBadQuestions().then((res) => {
-      setNumBadQuestions(res.data.numBadQuestions);
+      setNumBadQuestions(res.data.numBadQuestionsToday);
     });
 
     MetricsService.getAvgWaitTime().then((res) => {

--- a/client/src/components/metrics/PersonalStats.tsx
+++ b/client/src/components/metrics/PersonalStats.tsx
@@ -9,16 +9,17 @@ import {DateTime} from 'luxon';
 import MetricsService from '../../services/MetricsService';
 
 const columns = [
-  {id: 'andrewId', label: 'Andrew ID', width: 50},
-  {id: 'name', label: 'Name', width: 75},
+  {id: 'andrewId', label: 'Andrew ID', width: 25},
+  {id: 'name', label: 'Name', width: 25},
+  {id: 'question', label: 'Question', width: 200},
   {id: 'timeStart', label: 'Time Start', width: 100},
   {id: 'timeEnd', label: 'Time End', width: 100},
 ];
 
-function createData(andrewId, name, timeStart, timeEnd) {
+function createData(andrewId, name, timeStart, timeEnd, question) {
   timeStart = DateTime.fromISO(timeStart).toLocaleString(DateTime.DATETIME_MED);
   timeEnd = DateTime.fromISO(timeEnd).toLocaleString(DateTime.DATETIME_MED);
-  return {andrewId, name, timeStart, timeEnd};
+  return {andrewId, name, timeStart, timeEnd, question};
 }
 
 export default function PersonalStats() {
@@ -51,6 +52,7 @@ export default function PersonalStats() {
           helpedStudent.student_name,
           helpedStudent.start_date,
           helpedStudent.end_date,
+          helpedStudent.question,
       ));
     });
     setHelpedStudents(newRows);

--- a/server/controllers/metrics.js
+++ b/server/controllers/metrics.js
@@ -205,7 +205,17 @@ exports.get_ta_student_ratio_today = (req, res) => {
             return acc;
         }, {});
 
-        respond(req, res, "Got TA:Student ratio today", { taStudentRatio: Object.keys(taCount).length + ":" + Object.keys(studentCount).length }, 200);
+        function reduce(numerator,denominator){
+            var gcd = function gcd(a,b){
+              return b ? gcd(b, a%b) : a;
+            };
+            gcd = gcd(numerator,denominator);
+            return [numerator/gcd, denominator/gcd];
+          }
+
+        const ratio = reduce(Object.keys(taCount).length, Object.keys(studentCount).length);
+
+        respond(req, res, "Got TA:Student ratio today", { taStudentRatio: ratio[0] + ":" + ratio[1] }, 200);
     });
 }
 

--- a/server/controllers/metrics.js
+++ b/server/controllers/metrics.js
@@ -336,7 +336,6 @@ exports.get_num_students_per_day = (req, res) => {
         for (const row of data) {
             let datecount = row.dataValues;
             datecount.day_of_week = new Date(datecount.day_of_week).toLocaleDateString('en-US', {weekday : 'long'});
-            console.log(datecount);
             numStudentsPerDay.push({'day': datecount.day_of_week, 'students': datecount.count});
         }
 

--- a/server/controllers/metrics.js
+++ b/server/controllers/metrics.js
@@ -44,6 +44,7 @@ exports.get_helped_students = (req, res) => {
                 student_andrew: "",
                 start_date: question.help_time,
                 end_date: question.exit_time,
+                question: question.question
             });
 
             accountReqs.push(models.account.findByPk(question.student_id));

--- a/server/controllers/metrics.js
+++ b/server/controllers/metrics.js
@@ -156,6 +156,9 @@ exports.get_avg_wait_time_today = (req, res) => {
         where: {
             entry_time: {
                 [Sequelize.Op.gte]: today - 4 * 60 * 60 * 1000,
+            },
+            help_time: {
+                [Sequelize.Op.ne]: null,
             }
         }
     }).then(({count, rows}) =>  {
@@ -252,6 +255,9 @@ exports.get_total_avg_wait_time = (req, res) => {
 
     models.question.findAndCountAll({
         where: {
+            help_time: {
+                [Sequelize.Op.ne]: null,
+            }
         }
     }).then(({count, rows}) =>  {
 


### PR DESCRIPTION
After long last, I present to you.. a working metrics page (fixes #205 )

- number of bad questions is actually a number now
- average wait time (today and total) is no longer a victim of integer overflow
- time spent per question is no longer NaN but now aN
- table at the top now has student questions
- automatically reduces the TA:Student ratio
- last chart has accurate day of week now

However, axes don't work correctly yet -- SEE #222 

<img width="1361" alt="image" src="https://user-images.githubusercontent.com/46876327/215004187-be2b23a4-a985-4841-ae60-3c1943888972.png">
<img width="1358" alt="image" src="https://user-images.githubusercontent.com/46876327/215004200-ddb9c4bc-61a2-45ed-b55a-6dd41dffe868.png">
<img width="1341" alt="image" src="https://user-images.githubusercontent.com/46876327/215004214-70205cb9-9748-4cd7-a5f0-30d38dafcf6a.png">